### PR TITLE
Fix typo in NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,7 @@
 - **Function Integration**:
   - Included `plotSCC()` for visualization.
   - Included `generatePoissonClones()` for 1vsGroup setups.
-  - Included `calculateMetrics()` for performante estimation.
+  - Included `calculateMetrics()` for performance estimation.
 
 ### Major Changes
 


### PR DESCRIPTION
## Summary
- fix a typo in the v0.12.0 NEWS entry

## Testing
- `grep -n "performante" NEWS.md`